### PR TITLE
Add treatment-aware graph generator

### DIFF
--- a/cdt/data/__init__.py
+++ b/cdt/data/__init__.py
@@ -41,6 +41,9 @@ and acyclic graphs can be generated using the ``cdt.data.AcyclicGraphGenerator``
 .. SOFTWARE.
 """
 
-from .acyclic_graph_generator import AcyclicGraphGenerator
+from .acyclic_graph_generator import (
+    AcyclicGraphGenerator,
+    AcyclicGraphGeneratorTreatment,
+)
 from .causal_pair_generator import CausalPairGenerator
 from .loader import load_dataset

--- a/tests/scripts/test_generators.py
+++ b/tests/scripts/test_generators.py
@@ -1,7 +1,7 @@
 """Testing generators."""
 
 import networkx as nx
-from cdt.data import AcyclicGraphGenerator, CausalPairGenerator
+from cdt.data import AcyclicGraphGenerator, AcyclicGraphGeneratorTreatment, CausalPairGenerator
 from cdt.data.causal_mechanisms import gmm_cause, gaussian_cause
 import pandas as pd
 import os
@@ -62,6 +62,14 @@ def test_noises():
             data, agg = AcyclicGraphGenerator("linear", npoints=200, nodes=10, parents_max=3, noise=noise).generate()
             assert type(agg) == nx.DiGraph
             assert nx.is_directed_acyclic_graph(agg)
+
+
+def test_treatment_generator():
+    g = AcyclicGraphGeneratorTreatment('linear', npoints=200, nodes=10, parents_max=3)
+    data, agg = g.generate()
+    assert set(data['V0'].unique()).issubset({0, 1})
+    assert agg.in_degree('V0') == 0
+    assert nx.is_directed_acyclic_graph(agg)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- extend data generators with `AcyclicGraphGeneratorTreatment`
- export new generator in data module
- test new generator

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_687809418cf48332b04cb36bde9a8d9b